### PR TITLE
set cookie before header map is sent

### DIFF
--- a/chapter3/multipleMiddleware/main.go
+++ b/chapter3/multipleMiddleware/main.go
@@ -28,11 +28,11 @@ func filterContentType(handler http.Handler) http.Handler {
 
 func setServerTimeCookie(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handler.ServeHTTP(w, r)
 		// Setting cookie to every API response
-		cookie := http.Cookie{Name: "Server-Time(UTC)", Value: strconv.FormatInt(time.Now().Unix(), 10)}
+		cookie := http.Cookie{Name: "ServerTimeUTC", Value: strconv.FormatInt(time.Now().Unix(), 10)}
 		http.SetCookie(w, &cookie)
 		log.Println("Currently in the set server time middleware")
+		handler.ServeHTTP(w, r)
 	})
 }
 


### PR DESCRIPTION
$ go version
go version go1.15.8 darwin/amd64

1) http.SetCookie will silently drop the cookie header if name contains not allowed characters (parens in this case)
https://golang.org/pkg/net/http/#SetCookie
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie

2) calling original handler before writing cookie would silently drop the cookie since header map has been already sent to user
https://golang.org/pkg/net/http/#ResponseWriter 
https://golang.org/pkg/net/http/#ResponseWriter