### PR TITLE
use decrypt method in decrypt function

### DIFF
--- a/chapter11/encryptString/utils/utils.go
+++ b/chapter11/encryptString/utils/utils.go
@@ -30,7 +30,7 @@ func DecryptString(key, text string) string {
 		panic(err)
 	}
 	ciphertext, _ := base64.StdEncoding.DecodeString(text)
-	cfb := cipher.NewCFBEncrypter(block, initVector)
+	cfb := cipher.NewCFBDecrypter(block, initVector)
 	plaintext := make([]byte, len(ciphertext))
 	cfb.XORKeyStream(plaintext, ciphertext)
 	return string(plaintext)


### PR DESCRIPTION
I believe author by mistake used NewCFBEncrypter instead of NewCFBDecrypter while decrypting cipher text.
Although it's a good exercise for a learners to get more familiar with go errors and exceptions and try to troubleshoot them, I'm a little bit confused with the fact that broken code is committed into examples repo, which means that there were little or no technical review :)))) 
